### PR TITLE
Add Patch Tuesday export option

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,14 +6,15 @@ import random
 
 from config import CLIENTES, banners, banner, banner1, banner2, banner3 
 
-from exporters import exportar_assets, exportar_agents, exportar_vulnerabilidades 
+from exporters import exportar_assets, exportar_agents, exportar_vulnerabilidades
+from tuesday_api import exportar_patch_tuesday
 from utils import validar_credenciais, padronizar_excel_agents, inventario_software
 
 
 def main():
     parser = argparse.ArgumentParser(description="Exportador de Assets, Agents, Inventário de Software e Vulnerabilidades da Tenable")
     parser.add_argument('-c', '--cliente', help='Nome do cliente', required=False)
-    parser.add_argument('-t', '--tipo', choices=['assets', 'agents','inv', 'vuln'], help='Tipo de exportação', required=False)
+    parser.add_argument('-t', '--tipo', choices=['assets', 'agents', 'inv', 'vuln', 'tuesday'], help='Tipo de exportação', required=False)
     parser.add_argument('-f', '--filtro', choices=['offline', 'nogroup', 'all', 'compare'], help='Filtro para agentes', required=False)
     parser.add_argument('-p', '--padronizar',help='Caminho do arquivo CSV ou XLSX para padronizar a planilha Agents',required=False, metavar='ARQUIVO')
 
@@ -120,9 +121,10 @@ def main():
             print("\n[1] Exportar Assets")
             print("[2] Exportar Agents")
             print("[3] Software Inventory")
-            print("[4] Exportar Vulnerabilidades") 
+            print("[4] Exportar Vulnerabilidades")
+            print("[5] Exportar Patch Tuesday")
             tipo_input = input("\n \033[4mxtract\033[0m> ").strip()
-            
+
             if tipo_input == '1':
                 tipo = 'assets'
                 break
@@ -135,8 +137,11 @@ def main():
             elif tipo_input == '4':
                 tipo = 'vuln'
                 break
+            elif tipo_input == '5':
+                tipo = 'tuesday'
+                break
             else:
-                print("[\033[1;31m!\033[m] Tipo de exportação inválido. Por favor, escolha 1, 2, 3 ou 4.")
+                print("[\033[1;31m!\033[m] Tipo de exportação inválido. Por favor, escolha 1, 2, 3, 4 ou 5.")
 
     if tipo == 'assets':
         exportar_assets(tio, output_folder, cliente, assets_data=assets) 
@@ -168,6 +173,8 @@ def main():
         exportar_agents(tio, output_folder, cliente, filtro=filtro, agents_data=agentes) 
     elif tipo == 'inv':
         inventario_software(access_key, secret_key, output_folder, cliente)
+    elif tipo == 'tuesday':
+        exportar_patch_tuesday(tio, output_folder, cliente)
     elif tipo == 'vuln':
         severidade = args.s
         ultimos_dias = args.d

--- a/tuesday_api.py
+++ b/tuesday_api.py
@@ -1,0 +1,64 @@
+import os
+import re
+from datetime import datetime
+
+import arrow
+import pandas as pd
+
+from utils import formatar_aba, TenableIO
+
+
+def exportar_patch_tuesday(tio: TenableIO, output_folder: str, cliente: str):
+    """Exporta vulnerabilidades do Patch Tuesday para um arquivo Excel.
+
+    A função consulta a API de exportação de vulnerabilidades da Tenable filtrando
+    pelo plugin 93962 e registros vistos nos últimos 30 dias. O campo ``output``
+    é analisado para extrair a informação "Latest effective update level" e o
+    campo ``last_seen`` é formatado para o padrão ``dd/MM/YYYY``. São geradas duas
+    abas no Excel: ``Patch_Tuesday`` com todos os registros e ``Linux_Vulns`` com
+    registros cujo sistema operacional do asset corresponde a Linux.
+    """
+    try:
+        filtros = {
+            'plugin_id': [93962],
+            'last_seen': int(arrow.now().shift(days=-30).timestamp())
+        }
+        vulns = list(tio.exports.vulns(**filtros))
+
+        if not vulns:
+            print("[\033[1;33m!\033[m] Nenhuma vulnerabilidade encontrada para Patch Tuesday.")
+            return
+
+        df = pd.json_normalize(vulns, sep='.')
+
+        if 'output' in df.columns:
+            df['Latest effective update level'] = df['output'].str.extract(
+                r'Latest\s+effective\s+update\s+level\s*:?\s*(.*)',
+                expand=False
+            )
+        else:
+            df['Latest effective update level'] = ''
+
+        if 'last_seen' in df.columns:
+            df['last_seen'] = df['last_seen'].apply(
+                lambda x: datetime.fromtimestamp(int(x)).strftime('%d/%m/%Y')
+                if pd.notna(x) and str(x).isdigit() else x
+            )
+
+        linux_df = df[df['asset.operating_system'].str.contains(
+            r'linux', flags=re.IGNORECASE, na=False
+        )].copy()
+
+        output_file = os.path.join(output_folder, f'Tenable_patch_tuesday_{cliente}.xlsx')
+        with pd.ExcelWriter(output_file, engine='xlsxwriter') as writer:
+            df.to_excel(writer, sheet_name='Patch_Tuesday', index=False)
+            formatar_aba(writer, df, 'Patch_Tuesday')
+
+            linux_df.to_excel(writer, sheet_name='Linux_Vulns', index=False)
+            formatar_aba(writer, linux_df, 'Linux_Vulns')
+
+        print(f"[\033[1;32m✓\033[m] Exportação Patch Tuesday concluída: {output_file}")
+    except Exception as e:
+        import traceback
+        print(f"[\033[1;31m!\033[m] Erro ao exportar Patch Tuesday: {e}")
+        traceback.print_exc()


### PR DESCRIPTION
## Summary
- add Patch Tuesday export using plugin 93962 and last_seen 30 days
- hook up CLI option `tuesday` for exporting results

## Testing
- `python -m py_compile main.py tuesday_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa6cf383ac8327b2bd4d495c48de4d